### PR TITLE
Add force_new parameter to generate_csrf

### DIFF
--- a/flask_wtf/csrf.py
+++ b/flask_wtf/csrf.py
@@ -17,17 +17,23 @@ __all__ = ('generate_csrf', 'validate_csrf', 'CSRFProtect')
 logger = logging.getLogger(__name__)
 
 
-def generate_csrf(secret_key=None, token_key=None):
+def generate_csrf(secret_key=None, token_key=None, force_new=False):
     """Generate a CSRF token. The token is cached for a request, so multiple
     calls to this function will generate the same token.
+
+    To force generation of a new CSRF token (recommended during login and logout
+    of users), pass ``force_new=True``. This will reset the cached token, if one
+    exists, in both ``g.csrf_token`` and the session.
 
     During testing, it might be useful to access the signed token in
     ``g.csrf_token`` and the raw token in ``session['csrf_token']``.
 
     :param secret_key: Used to securely sign the token. Default is
         ``WTF_CSRF_SECRET_KEY`` or ``SECRET_KEY``.
-    :param token_key: Key where token is stored in session for comparision.
+    :param token_key: Key where token is stored in session for comparison.
         Default is ``WTF_CSRF_FIELD_NAME`` or ``'csrf_token'``.
+    :param force_new: When true, forces generation of a new CSRF token. Default
+        is ``False``.
     """
 
     secret_key = _get_config(
@@ -39,10 +45,10 @@ def generate_csrf(secret_key=None, token_key=None):
         message='A field name is required to use CSRF.'
     )
 
-    if field_name not in g:
+    if force_new or field_name not in g:
         s = URLSafeTimedSerializer(secret_key, salt='wtf-csrf-token')
 
-        if field_name not in session:
+        if force_new or field_name not in session:
             session[field_name] = hashlib.sha1(os.urandom(64)).hexdigest()
 
         try:

--- a/tests/test_csrf_form.py
+++ b/tests/test_csrf_form.py
@@ -40,6 +40,19 @@ def test_validate(req_ctx):
     validate_csrf(generate_csrf())
 
 
+def test_force_new_csrf(req_ctx):
+    old_signed_token = generate_csrf()
+    old_raw_token = session['csrf_token']
+
+    new_signed_token = generate_csrf(force_new=True)
+    new_raw_token = session['csrf_token']
+
+    assert old_signed_token != new_signed_token
+    assert old_raw_token != new_raw_token
+
+    validate_csrf(new_signed_token)
+
+
 def test_validation_errors(req_ctx):
     e = pytest.raises(ValidationError, validate_csrf, None)
     assert str(e.value) == 'The CSRF token is missing.'


### PR DESCRIPTION
Security best practices indicate CSRF tokens should be unique for each user session. Adding a `force_new` parameter to `generate_csrf` enables users to generate new CSRF tokens between user sessions with minimal code changes or understanding of CSRF generation internals required.